### PR TITLE
Fix static deinitialization fiasco in destructor

### DIFF
--- a/src/core/aql_profile.cpp
+++ b/src/core/aql_profile.cpp
@@ -42,7 +42,6 @@
 #include "core/commandbuffermgr.hpp"
 
 #define CONSTRUCTOR_API __attribute__((constructor))
-#define DESTRUCTOR_API __attribute__((destructor))
 #define ERR_CHECK(cond, err, msg) \
   {                               \
     if (cond) {                   \
@@ -159,12 +158,8 @@ hsa_status_t DefaultTracedataCallback(hsa_ven_amd_aqlprofile_info_type_t info_ty
   return status;
 }
 
-Logger::mutex_t Logger::mutex_;
-Logger* Logger::instance_ = NULL;
 bool Pm4Factory::concurrent_create_mode_ = false;
 bool Pm4Factory::spm_kfd_mode_ = false;
-Pm4Factory::mutex_t Pm4Factory::mutex_;
-Pm4Factory::instances_t* Pm4Factory::instances_ = NULL;
 bool read_api_enabled = true;
 
 CONSTRUCTOR_API void constructor() {
@@ -172,11 +167,6 @@ CONSTRUCTOR_API void constructor() {
   if (read_api_enabled_str != NULL) {
     if (atoi(read_api_enabled_str) == 0) read_api_enabled = false;
   }
-}
-
-DESTRUCTOR_API void destructor() {
-  Logger::Destroy();
-  Pm4Factory::Destroy();
 }
 
 }  // namespace aql_profile

--- a/src/core/logger.h
+++ b/src/core/logger.h
@@ -69,20 +69,13 @@ class Logger {
 
   static const std::string& LastMessage() {
     Logger& logger = Instance();
-    std::lock_guard<mutex_t> lck(mutex_);
+    std::lock_guard<mutex_t> lck(logger.mutex_);
     return logger.message_[GetTid()];
   }
 
   static Logger& Instance() {
-    std::lock_guard<mutex_t> lck(mutex_);
-    if (instance_ == NULL) instance_ = new Logger();
-    return *instance_;
-  }
-
-  static void Destroy() {
-    std::lock_guard<mutex_t> lck(mutex_);
-    if (instance_ != NULL) delete instance_;
-    instance_ = NULL;
+    static Logger instance;
+    return instance;
   }
 
  private:
@@ -143,8 +136,7 @@ class Logger {
   bool streaming_;
   bool messaging_;
 
-  static mutex_t mutex_;
-  static Logger* instance_;
+  mutex_t mutex_;
   std::map<uint32_t, std::string> message_;
 };
 

--- a/src/core/tests/aql_profile_tests.cpp
+++ b/src/core/tests/aql_profile_tests.cpp
@@ -38,8 +38,6 @@ using namespace testing;
 namespace aql_profile {
 bool Pm4Factory::concurrent_create_mode_ = false;
 bool Pm4Factory::spm_kfd_mode_ = false;
-Pm4Factory::mutex_t Pm4Factory::mutex_;
-Pm4Factory::instances_t* Pm4Factory::instances_ = nullptr;
 }
 
 // Mock classes to simulate Pm4Factory and related functionality


### PR DESCRIPTION
`aql_profile.cpp` defines:
```c++
Logger::mutex_t Logger::mutex_;

DESTRUCTOR_API void destructor() {
  Logger::Destroy();
  Pm4Factory::Destroy();
}
```

logger.h
```c++
  static void Destroy() {
    std::lock_guard<mutex_t> lck(mutex_);  // <--------------------- fails here
    if (instance_ != NULL) delete instance_;
    instance_ = NULL;
  }
```

There is no guarantees for destruction order, but in my case `__attribute__((destructor))`  runs after C++ destructors for static objects, trying to lock destroyed mutex.

To fix the deinitialization order, this PR removes custom destructor and replaces it with modern "Construct on First Use" idiom (a.k.a. Meyers' singletons).

Closes #4