### PR TITLE
Do not search for aqlprofile in /opt/rocm during tests

### DIFF
--- a/src/core/tests/CMakeLists.txt
+++ b/src/core/tests/CMakeLists.txt
@@ -4,14 +4,6 @@ include(GoogleTest)
 find_package(GTest REQUIRED)
 include_directories(${GTEST_INCLUDE_DIRS})
 
-
-find_library(
-    hsa-amd-aqlprofile64
-    REQUIRED
-    NAMES hsa-amd-aqlprofile64 hsa-amd-aqlprofile
-    HINTS /opt/rocm/lib /opt/rocm
-    PATHS /opt/rocm/lib /opt/rocm)
-
 # Add test for memory manager 
 add_executable(gfx9-memory-manager-test)
 SET(AQLPROFILE_MEMORYMANAGER_SOURCES
@@ -104,7 +96,7 @@ target_link_libraries(
     counters-test
     PRIVATE 
             hsa-runtime64::hsa-runtime64
-            ${hsa-amd-aqlprofile64}
+            ${AQLPROFILE_TARGET}
             GTest::gtest
             GTest::gtest_main
             GTest::gmock

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -64,7 +64,7 @@ foreach(target_id ${GPU_LIST})
   generate_hsaco(${target_id} ${TEST_DIR}/${TEST_NAME}/${TEST_NAME}.cl ${target_id}_${TEST_NAME}.hsaco)
 endforeach(target_id)
 # add_custom_target(test DEPENDS ${HSACO_TARGET_LIST})
-add_custom_target(mytest DEPENDS ${TARGET_NAME} ${HSACO_TARGET_LIST})
+add_custom_target(mytest ALL DEPENDS ${TARGET_NAME} ${HSACO_TARGET_LIST})
 
 ## Deploying test run scripts
 execute_process ( COMMAND sh -xc "cp --remove-destination ${TEST_DIR}/da_16b.py ${TEST_BINARY_DIR}" )

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -2,14 +2,6 @@ cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 project(Aqlprofile_v2_tests LANGUAGES C CXX HIP)
 set(CMAKE_CXX_STANDARD 17)
 
-
-find_library(
-    hsa-amd-aqlprofile64
-    REQUIRED
-    NAMES hsa-amd-aqlprofile64 hsa-amd-aqlprofile64
-    HINTS /opt/rocm/lib /opt/rocm
-    PATHS /opt/rocm/lib /opt/rocm)
-
 find_package(
     hsa-runtime64
     REQUIRED
@@ -51,13 +43,13 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O1" )
 add_library(intercept SHARED)
 target_include_directories(intercept PRIVATE ${HSA_RUNTIME_INC_PATH} ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/src/core/include/  /opt/rocm/include)
 target_sources(intercept PRIVATE intercept.cpp)
-target_link_libraries(intercept PRIVATE hsa-runtime64::hsa-runtime64 ${hsa-amd-aqlprofile64})
+target_link_libraries(intercept PRIVATE hsa-runtime64::hsa-runtime64 ${AQLPROFILE_TARGET})
 target_link_options(intercept PRIVATE -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exportmap -Wl,--no-undefined)
 target_compile_definitions(intercept PUBLIC AMD_INTERNAL_BUILD)
 add_executable(testv2)
 target_sources(testv2 PRIVATE main.cpp workload.cpp counter.cpp agent.cpp)
 target_include_directories(testv2 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/src/core/include/ ${HSA_RUNTIME_INC_PATH} /opt/rocm/include)
-target_link_libraries(testv2 PRIVATE hsa-runtime64::hsa-runtime64 ${hsa-amd-aqlprofile64})
+target_link_libraries(testv2 PRIVATE hsa-runtime64::hsa-runtime64 ${AQLPROFILE_TARGET})
 target_compile_definitions(testv2 PUBLIC AMD_INTERNAL_BUILD)
 
 # Add a PRELOAD environment with libintercept


### PR DESCRIPTION
As mentioned in Readme.txt (as expected), to run tests user should use `export LD_LIBRARY_PATH=$PWD`, so finding systemwide aqlprofile `/opt/rocm` is not needed.

Closes #6